### PR TITLE
Fix websocket library missing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,4 +33,4 @@ requests==2.31.0
 urllib3==1.26.16
 whitenoise==6.5.0
 django-redis==5.3.0
-uvicorn
+uvicorn[standard]==0.35.0


### PR DESCRIPTION
## Summary
- install websockets support via `uvicorn[standard]`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860de039980832c881d3adc376bf195